### PR TITLE
+Action: Edit+ fix test fails type mismatch (fixed #1)

### DIFF
--- a/maintenance/tests/liblbeetest/liblbeetest.c
+++ b/maintenance/tests/liblbeetest/liblbeetest.c
@@ -5,7 +5,7 @@
 #include <glib/gstdio.h>
 #include <libeventemitter.h>
 
-gboolean fail = 0;
+guint fail = 0;
 
 void lbeerunone(LBEE_TestCase *testcase, gpointer user_data) {
     gchar *template = g_strdup("/tmp/LBEETEST_XXXXXX");


### PR DESCRIPTION
我修复了 1 号 issue。
问题的原因是 类型不匹配。
改动了 liblbeetest.c 文件。
# 测试（可选）
我添加了以下单元测试：
* ____ (名字)
* ...
# 文档（可选）
## docs
我添加了以下文档：
* ____
* ...
## 手册
我在手册里添加了 ____ 章节。